### PR TITLE
Adds support for Anthropic's messages API

### DIFF
--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -16,6 +16,39 @@ module Anthropic
       Anthropic::Client.json_post(path: "/complete", parameters: parameters)
     end
 
+      def messages(model:, messages:, system: nil, parameters: {}) # rubocop:disable Metrics/MethodLength
+      parameters.merge!(system: system) if system
+      parameters.merge!(model: model, messages: messages)
+
+      max_attempts = 5
+      attempts = 0
+
+      # TODO: does this level of retry implementation belong here?
+      loop do
+        attempts += 1
+        Anthropic::Client.json_post(path: "/messages", parameters: parameters).tap do |response|
+          # handle successful response
+          return response if response.dig("content", 0, "text")
+
+          # handle max attempts
+          if attempts > max_attempts
+            raise Anthropic::Error,
+                  "Failed after #{max_attempts} attempts. #{error_message}"
+          end
+
+          # handle error response
+          error_type = response.dig("error", "type")
+          error_message = response.dig("error", "message")
+          if %w[overloaded_error api_error rate_limit_error].include?(error_type) # rubocop:disable Style/GuardClause
+            # retry loop with exponential backoff
+            sleep(1 * attempts)
+          else
+            raise Anthropic::Error, error_message
+          end
+        end
+      end
+    end
+
     private
 
     def wrap_prompt(prompt:, prefix: "\n\nHuman: ", suffix: "\n\nAssistant:")

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -15,38 +15,11 @@ module Anthropic
       parameters[:prompt] = wrap_prompt(prompt: parameters[:prompt])
       Anthropic::Client.json_post(path: "/complete", parameters: parameters)
     end
-
-      def messages(model:, messages:, system: nil, parameters: {}) # rubocop:disable Metrics/MethodLength
+        
+    def messages(model:, messages:, system: nil, parameters: {}) # rubocop:disable Metrics/MethodLength
       parameters.merge!(system: system) if system
       parameters.merge!(model: model, messages: messages)
-
-      max_attempts = 5
-      attempts = 0
-
-      # TODO: does this level of retry implementation belong here?
-      loop do
-        attempts += 1
-        Anthropic::Client.json_post(path: "/messages", parameters: parameters).tap do |response|
-          # handle successful response
-          return response if response.dig("content", 0, "text")
-
-          # handle max attempts
-          if attempts > max_attempts
-            raise Anthropic::Error,
-                  "Failed after #{max_attempts} attempts. #{error_message}"
-          end
-
-          # handle error response
-          error_type = response.dig("error", "type")
-          error_message = response.dig("error", "message")
-          if %w[overloaded_error api_error rate_limit_error].include?(error_type) # rubocop:disable Style/GuardClause
-            # retry loop with exponential backoff
-            sleep(1 * attempts)
-          else
-            raise Anthropic::Error, error_message
-          end
-        end
-      end
+      Anthropic::Client.json_post(path: "/messages", parameters: parameters)
     end
 
     private

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -16,9 +16,7 @@ module Anthropic
       Anthropic::Client.json_post(path: "/complete", parameters: parameters)
     end
         
-    def messages(model:, messages:, system: nil, parameters: {}) # rubocop:disable Metrics/MethodLength
-      parameters.merge!(system: system) if system
-      parameters.merge!(model: model, messages: messages)
+    def messages(parameters: {}) # rubocop:disable Metrics/MethodLength
       Anthropic::Client.json_post(path: "/messages", parameters: parameters)
     end
 

--- a/spec/anthropic/client/messages_spec.rb
+++ b/spec/anthropic/client/messages_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe Anthropic::Client do
 
       let(:response) do
         Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY']).messages(
-          model: model,
-          messages: [
-            {
-              role: "user",
-              content: "How High is the Sky?"
-            }
-          ],
           parameters: {
+            model: model,
+            messages: [
+              {
+                role: "user",
+                content: "How High is the Sky?"
+              }
+            ],
             max_tokens: max_tokens,
           }
         )

--- a/spec/anthropic/client/messages_spec.rb
+++ b/spec/anthropic/client/messages_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Anthropic::Client do
-  describe "#complete" do
+  describe "#messages" do
     context "with a prompt and max_tokens", :vcr do
       let(:prompt) { "How high is the sky?" }
       let(:max_tokens) { 5 }

--- a/spec/anthropic/client/messages_spec.rb
+++ b/spec/anthropic/client/messages_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Anthropic::Client do
+  describe "#complete" do
+    context "with a prompt and max_tokens", :vcr do
+      let(:prompt) { "How high is the sky?" }
+      let(:max_tokens) { 5 }
+
+      let(:response) do
+        Anthropic::Client.new(access_token: ENV['ANTHROPIC_API_KEY']).messages(
+          model: model,
+          messages: [
+            {
+              role: "user",
+              content: "How High is the Sky?"
+            }
+          ],
+          parameters: {
+            max_tokens: max_tokens,
+          }
+        )
+      end
+      let(:text) { response.dig("choices", 0, "text") }
+      let(:cassette) { "#{model} complete #{prompt}".downcase }
+
+      context "with model: claude-2.1" do
+        let(:model) { "claude-2.1" }
+
+        it "succeeds" do
+          VCR.use_cassette(cassette) do
+            expect(response["content"].empty?).to eq(false)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/cassettes/claude-2_1_complete_how_high_is_the_sky_.yml
+++ b/spec/fixtures/cassettes/claude-2_1_complete_how_high_is_the_sky_.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages
+    body:
+      encoding: UTF-8
+      string: '{"max_tokens":5,"model":"claude-2.1","messages":[{"role":"user","content":"How
+        High is the Sky?"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 10 Mar 2024 07:48:04 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Anthropic-Ratelimit-Requests-Limit:
+      - '5'
+      Anthropic-Ratelimit-Requests-Remaining:
+      - '4'
+      Anthropic-Ratelimit-Requests-Reset:
+      - '2024-03-10T07:49:00Z'
+      Anthropic-Ratelimit-Tokens-Limit:
+      - '25000'
+      Anthropic-Ratelimit-Tokens-Remaining:
+      - '25000'
+      Anthropic-Ratelimit-Tokens-Reset:
+      - '2024-03-10T07:49:00Z'
+      Request-Id:
+      - req_01JEZGZ48oJu1J9jWiiwi1p8
+      X-Cloud-Trace-Context:
+      - 325b20d2b1b2ecb600f1a72cdf02ede5
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8621b33dfdd5f2b2-BOM
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msg_01FXDmQFKWtuU462tWUdfrvE","type":"message","role":"assistant","content":[{"type":"text","text":"The
+        sky doesn''t have"}],"model":"claude-2.1","stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":5}}'
+  recorded_at: Sun, 10 Mar 2024 07:48:04 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/cassettes/claude-2_1_complete_how_high_is_the_sky_.yml
+++ b/spec/fixtures/cassettes/claude-2_1_complete_how_high_is_the_sky_.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://api.anthropic.com/v1/messages
     body:
       encoding: UTF-8
-      string: '{"max_tokens":5,"model":"claude-2.1","messages":[{"role":"user","content":"How
-        High is the Sky?"}]}'
+      string: '{"model":"claude-2.1","messages":[{"role":"user","content":"How High
+        is the Sky?"}],"max_tokens":5}'
     headers:
       Content-Type:
       - application/json
@@ -26,7 +26,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 10 Mar 2024 07:48:04 GMT
+      - Sun, 10 Mar 2024 07:54:21 GMT
       Content-Type:
       - application/json
       Transfer-Encoding:
@@ -38,17 +38,17 @@ http_interactions:
       Anthropic-Ratelimit-Requests-Remaining:
       - '4'
       Anthropic-Ratelimit-Requests-Reset:
-      - '2024-03-10T07:49:00Z'
+      - '2024-03-10T07:55:00Z'
       Anthropic-Ratelimit-Tokens-Limit:
       - '25000'
       Anthropic-Ratelimit-Tokens-Remaining:
       - '25000'
       Anthropic-Ratelimit-Tokens-Reset:
-      - '2024-03-10T07:49:00Z'
+      - '2024-03-10T07:55:00Z'
       Request-Id:
-      - req_01JEZGZ48oJu1J9jWiiwi1p8
+      - req_011UY7uReMm6iSVMsdf3awWH
       X-Cloud-Trace-Context:
-      - 325b20d2b1b2ecb600f1a72cdf02ede5
+      - bad60d49baf5dd72ea7ebe52ca0878d4
       Via:
       - 1.1 google
       Cf-Cache-Status:
@@ -56,10 +56,10 @@ http_interactions:
       Server:
       - cloudflare
       Cf-Ray:
-      - 8621b33dfdd5f2b2-BOM
+      - 8621bc760b43f55f-BOM
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"msg_01FXDmQFKWtuU462tWUdfrvE","type":"message","role":"assistant","content":[{"type":"text","text":"The
-        sky doesn''t have"}],"model":"claude-2.1","stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":5}}'
-  recorded_at: Sun, 10 Mar 2024 07:48:04 GMT
+      string: '{"id":"msg_013xVudG9xjSvLGwPKMeVXzG","type":"message","role":"assistant","content":[{"type":"text","text":"The
+        sky has no distinct"}],"model":"claude-2.1","stop_reason":"max_tokens","stop_sequence":null,"usage":{"input_tokens":15,"output_tokens":5}}'
+  recorded_at: Sun, 10 Mar 2024 07:54:21 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
I saw @obie's PR and improved on it slightly.

- I removed the use of `present?` which is a Rails-only method so the library works outside of Rails as well
- I removed the retry logic which I believe should be a concern of the caller. This gem should faithfully report whatever Anthropic API returns
- I am also not a fan of having the `messages` function API break out the parameters. I understand it makes it marginally easier to call the API but there should also be a 1:1 mapping between the Anthropic API docs and our gem, which @obie's API breaks. 
- I added a spec for the new method.

Hope this helps.
