### PR TITLE
Fix streaming error if using Faraday < 2.5.0

### DIFF
--- a/lib/anthropic/http.rb
+++ b/lib/anthropic/http.rb
@@ -73,7 +73,9 @@ module Anthropic
       preprocess_stack = ""
 
       proc do |chunk, _bytes, env|
-        handle_faraday_error(chunk, env)
+        # Versions of Faraday < 2.5.0 do not include an `env` argument,
+        # so we have to assume they are successful
+        handle_faraday_error(chunk, env) if env
 
         parser.feed(chunk) do |type, data|
           parsed_data = JSON.parse(data)


### PR DESCRIPTION
The streaming proc method signature changed in Faraday 2.5.0, and any older version only provides the first two arguments to the proc ([see 6799f58](https://github.com/lostisland/faraday/commit/6799f5852d31dae32699949790633c68282ab71d)).

If using an older version of Faraday, we don't have a way to know if the streaming response is successful, so we just assume it is.
