### PR TITLE
Fix gem crashing when content_block_delta contains partial_json inste…

### DIFF
--- a/lib/anthropic/http.rb
+++ b/lib/anthropic/http.rb
@@ -99,7 +99,7 @@ module Anthropic
         response.merge!(parsed_data["delta"])
       when "content_block_delta"
         delta = parsed_data["delta"]["text"]
-        response["content"][0]["text"].concat(delta)
+        response["content"][0]["text"].concat(delta) if delta
         block.yield delta
       end
     end


### PR DESCRIPTION
When using tools with the Anthropic API ( https://docs.anthropic.com/en/docs/build-with-claude/tool-use ), the API will return a second set of content that doesn't contain text in the "content_block_delta" and will crash the gem.

This PR patches the error by checking if the text is present in the "content_block_delta"

## All Submissions:

* [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
