### PR TITLE
Added Anthropic Batch Messages API reducing 💸 significantly  

### DIFF
--- a/lib/anthropic/batch.rb
+++ b/lib/anthropic/batch.rb
@@ -1,38 +1,55 @@
 module Anthropic
-  class Batch
+  class MessagesBatcher
     def initialize(client)
       @client = client
     end
 
-    # Anthropic API Parameters as of 2024-10-09:
-    #   @see https://docs.anthropic.com/en/api/creating-message-batches
-    #
-    # @param [Array] :requests - List of requests for prompt completion. Each is an individual request to create a Message.
-    #   Requests are an array of hashes, each with the following keys:
-    #   - :custom_id (required): Developer-provided ID created for each request in a Message Batch.
-    #                            Useful for matching results to requests, as results may be given out of request order.
-    #                            Must be unique for each request within the Message Batch.
-    #   - :params (required): Messages API creation parameters for the individual request.
-    #                            See the Messages API reference for full documentation on available parameters.
-    #
-    # @returns [Hash] the response from the API (after the streaming is done, if streaming)
-    #   @example:
-    #
-    # > messages.batch(requests_parameters)
-    # {
-    #   "id"=>"msgbatch_01668jySCZeCpMLsxFcroNnN",
-    #   "type"=>"message_batch",
-    #   "processing_status"=>"in_progress",
-    #   "request_counts"=>{"processing"=>2, "succeeded"=>0, "errored"=>0, "canceled"=>0, "expired"=>0},
-    #   "ended_at"=>nil,
-    #   "created_at"=>"2024-10-09T20:18:11.480471+00:00",
-    #   "expires_at"=>"2024-10-10T20:18:11.480471+00:00",
-    #   "cancel_initiated_at"=>nil,
-    #   "results_url"=>nil
-    # }
-    def batch(requests_parameters)
-      custom_headers = { "anthropic-beta" => "message-batches-2024-09-24" }
-      @client.json_post(path: "/messages/batches", parameters: { "requests" => requests_parameters }, custom_headers:)
+    def batch
+      Batcher.new(@client)
+    end
+
+    class Batcher < MessagesBatcher
+      # Anthropic API Parameters as of 2024-10-09:
+      #   @see https://docs.anthropic.com/en/api/creating-message-batches
+      #
+      # @param [Array] :requests - List of requests for prompt completion.
+      #  Each is an individual request to create a Message.
+      #  Requests are an array of hashes, each with the following keys:
+      #  - :custom_id (required): Developer-provided ID created for each request in a Message Batch.
+      #     Useful for matching results to requests, as results may be given out of request order.
+      #     Must be unique for each request within the Message Batch.
+      #  - :params (required): Messages API creation parameters for the individual request.
+      #     See the Messages API reference for full documentation on available parameters.
+      #
+      # @returns [Hash] the response from the API (after the streaming is done, if streaming)
+      #   @example:
+      #
+      # > messages.batch(requests_parameters)
+      # {
+      #   "id"=>"msgbatch_01668jySCZeCpMLsxFcroNnN",
+      #   "type"=>"message_batch",
+      #   "processing_status"=>"in_progress",
+      #   "request_counts"=>{
+      #     "processing"=>2,
+      #     "succeeded"=>0,
+      #     "errored"=>0,
+      #     "canceled"=>0,
+      #     "expired"=>0
+      #   },
+      #   "ended_at"=>nil,
+      #   "created_at"=>"2024-10-09T20:18:11.480471+00:00",
+      #   "expires_at"=>"2024-10-10T20:18:11.480471+00:00",
+      #   "cancel_initiated_at"=>nil,
+      #   "results_url"=>nil
+      # }
+      def create(requests_parameters)
+        custom_headers = { "anthropic-beta" => "message-batches-2024-09-24" }
+        @client.json_post(
+          path: "/messages/batches",
+          parameters: { "requests" => requests_parameters },
+          custom_headers: custom_headers
+        )
+      end
     end
   end
 end

--- a/lib/anthropic/batch.rb
+++ b/lib/anthropic/batch.rb
@@ -1,0 +1,38 @@
+module Anthropic
+  class Batch
+    def initialize(client)
+      @client = client
+    end
+
+    # Anthropic API Parameters as of 2024-10-09:
+    #   @see https://docs.anthropic.com/en/api/creating-message-batches
+    #
+    # @param [Array] :requests - List of requests for prompt completion. Each is an individual request to create a Message.
+    #   Requests are an array of hashes, each with the following keys:
+    #   - :custom_id (required): Developer-provided ID created for each request in a Message Batch.
+    #                            Useful for matching results to requests, as results may be given out of request order.
+    #                            Must be unique for each request within the Message Batch.
+    #   - :params (required): Messages API creation parameters for the individual request.
+    #                            See the Messages API reference for full documentation on available parameters.
+    #
+    # @returns [Hash] the response from the API (after the streaming is done, if streaming)
+    #   @example:
+    #
+    # > messages.batch(requests_parameters)
+    # {
+    #   "id"=>"msgbatch_01668jySCZeCpMLsxFcroNnN",
+    #   "type"=>"message_batch",
+    #   "processing_status"=>"in_progress",
+    #   "request_counts"=>{"processing"=>2, "succeeded"=>0, "errored"=>0, "canceled"=>0, "expired"=>0},
+    #   "ended_at"=>nil,
+    #   "created_at"=>"2024-10-09T20:18:11.480471+00:00",
+    #   "expires_at"=>"2024-10-10T20:18:11.480471+00:00",
+    #   "cancel_initiated_at"=>nil,
+    #   "results_url"=>nil
+    # }
+    def batch(requests_parameters)
+      custom_headers = { "anthropic-beta" => "message-batches-2024-09-24" }
+      @client.json_post(path: "/messages/batches", parameters: { "requests" => requests_parameters }, custom_headers:)
+    end
+  end
+end

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -67,6 +67,36 @@ module Anthropic
       json_post(path: "/messages", parameters: parameters)
     end
 
+    # Anthropic API Parameters as of 2024-10-09:
+    #   @see https://docs.anthropic.com/en/api/creating-message-batches
+    #
+    # @param [Array] :requests - List of requests for prompt completion. Each is an individual request to create a Message.
+    #   Requests are an array of hashes, each with the following keys:
+    #   - :custom_id (required): Developer-provided ID created for each request in a Message Batch.
+    #                            Useful for matching results to requests, as results may be given out of request order.
+    #                            Must be unique for each request within the Message Batch.
+    #   - :params (required): Messages API creation parameters for the individual request.
+    #                            See the Messages API reference for full documentation on available parameters.
+    #
+    # @returns [Hash] the response from the API (after the streaming is done, if streaming)
+    #   @example:
+    # {
+    #   "id"=>"msgbatch_01668jySCZeCpMLsxFcroNnN",
+    #   "type"=>"message_batch",
+    #   "processing_status"=>"in_progress",
+    #   "request_counts"=>{"processing"=>2, "succeeded"=>0, "errored"=>0, "canceled"=>0, "expired"=>0},
+    #   "ended_at"=>nil,
+    #   "created_at"=>"2024-10-09T20:18:11.480471+00:00",
+    #   "expires_at"=>"2024-10-10T20:18:11.480471+00:00",
+    #   "cancel_initiated_at"=>nil,
+    #   "results_url"=>nil
+    # }
+    def batch_messages(requests_parameters)
+      # required to use the Batch API. https://docs.anthropic.com/en/docs/build-with-claude/message-batches
+      custom_headers = { "anthropic-beta" => "message-batches-2024-09-24" }
+      json_post(path: "/messages/batches", parameters: { "requests" => requests_parameters }, custom_headers:)
+    end
+
     private
 
     # Used only by @deprecated +complete+ method

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -66,7 +66,7 @@ module Anthropic
     #   "usage" => {"input_tokens" => 15, "output_tokens" => 5}
     # }
     def messages(**args)
-      return Batch.new(self) unless args && args[:parameters]
+      return MessagesBatcher.new(self) unless args && args[:parameters]
 
       json_post(path: "/messages", parameters: args[:parameters])
     end

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -1,3 +1,5 @@
+require_relative "batch"
+
 module Anthropic
   class Client
     include Anthropic::HTTP
@@ -63,53 +65,10 @@ module Anthropic
     #   "stop_sequence" => nil,
     #   "usage" => {"input_tokens" => 15, "output_tokens" => 5}
     # }
-    def messages(parameters: {})
-      json_post(path: "/messages", parameters: parameters)
-    end
+    def messages(**args)
+      return Batch.new(self) unless args && args[:parameters]
 
-    # Anthropic API Parameters as of 2024-10-09:
-    #   @see https://docs.anthropic.com/en/api/creating-message-batches
-    #
-    # @param [Array] :requests - List of requests for prompt completion. Each is an individual request to create a Message.
-    #   Requests are an array of hashes, each with the following keys:
-    #   - :custom_id (required): Developer-provided ID created for each request in a Message Batch.
-    #                            Useful for matching results to requests, as results may be given out of request order.
-    #                            Must be unique for each request within the Message Batch.
-    #   - :params (required): Messages API creation parameters for the individual request.
-    #                            See the Messages API reference for full documentation on available parameters.
-    #
-    # @returns [Hash] the response from the API (after the streaming is done, if streaming)
-    #   @example:
-    # {
-    #   "id"=>"msgbatch_01668jySCZeCpMLsxFcroNnN",
-    #   "type"=>"message_batch",
-    #   "processing_status"=>"in_progress",
-    #   "request_counts"=>{"processing"=>2, "succeeded"=>0, "errored"=>0, "canceled"=>0, "expired"=>0},
-    #   "ended_at"=>nil,
-    #   "created_at"=>"2024-10-09T20:18:11.480471+00:00",
-    #   "expires_at"=>"2024-10-10T20:18:11.480471+00:00",
-    #   "cancel_initiated_at"=>nil,
-    #   "results_url"=>nil
-    # }
-    def batch_messages(requests_parameters)
-      # required to use the Batch API. https://docs.anthropic.com/en/docs/build-with-claude/message-batches
-      custom_headers = { "anthropic-beta" => "message-batches-2024-09-24" }
-      json_post(path: "/messages/batches", parameters: { "requests" => requests_parameters }, custom_headers:)
-    end
-
-    # allows using the batch API via `client.messages.batch` method.
-    def messages
-      MessagesBatcher.new(self)
-    end
-
-    class MessagesBatcher
-      def initialize(client)
-        @client = client
-      end
-
-      def batch(requests_parameters)
-        @client.batch_messages(requests_parameters)
-      end
+      json_post(path: "/messages", parameters: args[:parameters])
     end
 
     private

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -97,6 +97,21 @@ module Anthropic
       json_post(path: "/messages/batches", parameters: { "requests" => requests_parameters }, custom_headers:)
     end
 
+    # allows using the batch API via `client.messages.batch` method.
+    def messages
+      MessagesBatcher.new(self)
+    end
+
+    class MessagesBatcher
+      def initialize(client)
+        @client = client
+      end
+
+      def batch(requests_parameters)
+        @client.batch_messages(requests_parameters)
+      end
+    end
+
     private
 
     # Used only by @deprecated +complete+ method

--- a/lib/anthropic/http.rb
+++ b/lib/anthropic/http.rb
@@ -16,10 +16,10 @@ module Anthropic
 
     # This is currently the workhorse for all API calls.
     # rubocop:disable Metrics/MethodLength
-    def json_post(path:, parameters:)
+    def json_post(path:, parameters:, custom_headers: {})
       str_resp = {}
       response = conn.post(uri(path: path)) do |req|
-        if parameters[:stream].is_a?(Proc)
+        if parameters.respond_to?(:key?) && parameters[:stream].is_a?(Proc)
           req.options.on_data = to_json_stream(user_proc: parameters[:stream], response: str_resp,
                                                preprocess: parameters[:preprocess_stream])
           parameters[:stream] = true # Necessary to tell Anthropic to stream.
@@ -27,6 +27,7 @@ module Anthropic
         end
 
         req.headers = headers
+        req.headers.merge!(custom_headers) if custom_headers.any?
         req.body = parameters.to_json
       end
 

--- a/lib/anthropic/http.rb
+++ b/lib/anthropic/http.rb
@@ -16,6 +16,7 @@ module Anthropic
 
     # This is currently the workhorse for all API calls.
     # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize
     def json_post(path:, parameters:, custom_headers: {})
       str_resp = {}
       response = conn.post(uri(path: path)) do |req|
@@ -34,6 +35,7 @@ module Anthropic
       str_resp.empty? ? response.body : str_resp
     end
     # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize
 
     # Unused?
     def multipart_post(path:, parameters: nil)

--- a/spec/anthropic/client/messages/batch_spec.rb
+++ b/spec/anthropic/client/messages/batch_spec.rb
@@ -4,41 +4,41 @@ RSpec.describe Anthropic::Client do
 
   describe "#messages.batch" do
     context "batch messages" do
-      let(:request_1) do
+      let(:request1) do
         {
           custom_id: "first-prompt-in-my-batch",
           params: {
-              model: "claude-3-haiku-20240307",
-              max_tokens: 100,
-              messages: [
-                  {
-                      "role": "user",
-                      "content": "Hey Claude, tell me a short fun fact about video games!",
-                  }
-              ],
-          },
+            model: "claude-3-haiku-20240307",
+            max_tokens: 100,
+            messages: [
+              {
+                role: "user",
+                content: "Hey Claude, tell me a short fun fact about video games!"
+              }
+            ]
+          }
         }
       end
 
-      let(:request_2) do
+      let(:request2) do
         {
           custom_id: "second-prompt-in-my-batch",
           params: {
-              model: "claude-3-5-sonnet-20240620",
-              max_tokens: 100,
-              "messages": [
-                  {
-                      "role": "user",
-                      "content": "Hey Claude, tell me a short fun fact about bees!",
-                  }
-              ],
-          },
+            model: "claude-3-5-sonnet-20240620",
+            max_tokens: 100,
+            messages: [
+              {
+                role: "user",
+                content: "Hey Claude, tell me a short fun fact about bees!"
+              }
+            ]
+          }
         }
       end
 
       let(:response) do
-        Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY", nil)).batch_messages(
-          [request_1, request_2]
+        Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY", nil)).messages.batch(
+          [request1, request2]
         )
       end
 

--- a/spec/anthropic/client/messages/batch_spec.rb
+++ b/spec/anthropic/client/messages/batch_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe Anthropic::Client do
   let(:json_prompt) { "Answer in the provided JSON format. Only include JSON." }
 
   describe "#messages.batch" do
-    context "batch messages" do
+    context "#create batch messages" do
       let(:request1) do
         {
           custom_id: "first-prompt-in-my-batch",
@@ -37,9 +37,10 @@ RSpec.describe Anthropic::Client do
       end
 
       let(:response) do
-        Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY", nil)).messages.batch(
-          [request1, request2]
-        )
+        Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY",
+                                                      nil)).messages.batch.create(
+                                                        [request1, request2]
+                                                      )
       end
 
       it "succeeds" do

--- a/spec/anthropic/client/messages/batch_spec.rb
+++ b/spec/anthropic/client/messages/batch_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe Anthropic::Client do
+  let(:client) { Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY", nil)) }
+  let(:json_prompt) { "Answer in the provided JSON format. Only include JSON." }
+
+  describe "#messages.batch" do
+    context "batch messages" do
+      let(:request_1) do
+        {
+          custom_id: "first-prompt-in-my-batch",
+          params: {
+              model: "claude-3-haiku-20240307",
+              max_tokens: 100,
+              messages: [
+                  {
+                      "role": "user",
+                      "content": "Hey Claude, tell me a short fun fact about video games!",
+                  }
+              ],
+          },
+        }
+      end
+
+      let(:request_2) do
+        {
+          custom_id: "second-prompt-in-my-batch",
+          params: {
+              model: "claude-3-5-sonnet-20240620",
+              max_tokens: 100,
+              "messages": [
+                  {
+                      "role": "user",
+                      "content": "Hey Claude, tell me a short fun fact about bees!",
+                  }
+              ],
+          },
+        }
+      end
+
+      let(:response) do
+        Anthropic::Client.new(access_token: ENV.fetch("ANTHROPIC_API_KEY", nil)).batch_messages(
+          [request_1, request_2]
+        )
+      end
+
+      it "succeeds" do
+        cassette = "batch_messages"
+        VCR.use_cassette(cassette) do
+          expect(response["id"].empty?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/cassettes/batch_messages.yml
+++ b/spec/fixtures/cassettes/batch_messages.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.anthropic.com/v1/messages/batches
+    body:
+      encoding: UTF-8
+      string: '{"requests":[{"custom_id":"first-prompt-in-my-batch","params":{"model":"claude-3-haiku-20240307","max_tokens":100,"messages":[{"role":"user","content":"Hey
+        Claude, tell me a short fun fact about video games!"}]}},{"custom_id":"second-prompt-in-my-batch","params":{"model":"claude-3-5-sonnet-20240620","max_tokens":100,"messages":[{"role":"user","content":"Hey
+        Claude, tell me a short fun fact about bees!"}]}}]}'
+    headers:
+      X-Api-Key:
+      - "<ANTHROPIC_API_KEY>"
+      Anthropic-Version:
+      - '2023-06-01'
+      Content-Type:
+      - application/json
+      Anthropic-Beta:
+      - message-batches-2024-09-24
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 09 Oct 2024 20:47:26 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Request-Id:
+      - req_01WG8SGepvZ3bS3cdVDuWjTW
+      X-Cloud-Trace-Context:
+      - f7d1ee5f8a847aed54bc809d0f7c79bc
+      Via:
+      - 1.1 google
+      Cf-Cache-Status:
+      - DYNAMIC
+      X-Robots-Tag:
+      - none
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 8d0139cf7acffbb2-POA
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"msgbatch_01UnEPrhN631BC6548pxNQ6q","type":"message_batch","processing_status":"in_progress","request_counts":{"processing":2,"succeeded":0,"errored":0,"canceled":0,"expired":0},"ended_at":null,"created_at":"2024-10-09T20:47:26.801533+00:00","expires_at":"2024-10-10T20:47:26.801533+00:00","cancel_initiated_at":null,"results_url":null}'
+  recorded_at: Wed, 09 Oct 2024 20:47:26 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
👋 This PR allows sending messages in batches to reduce 💸 massively. 
<img width="1504" alt="Screenshot 2024-10-09 at 6 20 19 PM" src="https://github.com/user-attachments/assets/1ef95ec2-1901-4ae1-975e-44eeeb1b6c09">

[Documentation](https://docs.anthropic.com/en/api/creating-message-batches)

The API lets you send multiple messages in a single API call at a much lower cost. The API response does not immediately return the LLM answer; instead, it gives you the status of the process. 

```ruby
client.messages.batch.create([message1, message2,...])
```

### Implementation

I used the API `client.messages.batch` instead of a new method like `client.messages_batch`. For that, I introduced a class `Messages` that is returned whenever `client.messages` is called, allowing to call the public class' methods like the example below:

```ruby
require 'bundler/inline'

gemfile(true) do
  source 'https://rubygems.org'
  git_source(:github) { |repo| "https://github.com/#{repo}.git" }
  gem "anthropic", path: "../"
end

require 'anthropic'

client = Anthropic::Client.new(access_token: ENV[:your-key])

response = client.messages.batch.create(
  [
      {
          custom_id: "first-prompt-in-my-batch",
          params: {
              model: "claude-3-haiku-20240307",
              max_tokens: 100,
              messages: [
                  {
                      "role": "user",
                      "content": "Tell me a short fun fact about football!",
                  }
              ],
          },
      },
      {
          custom_id: "second-prompt-in-my-batch",
          params: {
              model: "claude-3-5-sonnet-20240620",
              max_tokens: 100,
              "messages": [
                  {
                      "role": "user", "content": "Tell me a short, fun fact about bees!",
                  }
              ],
          },
      },
  ]
)

# => {"id"=>"msgbatch_01E7yY37TgWmm8pBs5LHE1y5",
#  "type"=>"message_batch",
#  "processing_status"=>"in_progress",
#  "request_counts"=>{"processing"=>2, "succeeded"=>0, "errored"=>0, "canceled"=>0, "expired"=>0},
#  "ended_at"=>nil,
#  "created_at"=>"2024-10-09T21:17:36.478240+00:00",
#  "expires_at"=>"2024-10-10T21:17:36.478240+00:00",
#  "cancel_initiated_at"=>nil,
#  "results_url"=>nil}
```
# 

The API has some gotchas, like using a header (since it's in beta).

Note: The [API provides] more methods (https://docs.anthropic.com/en/api/retrieving-message-batches).

# API design

The Batch API supports CRUD methods along with other methods; for that, I decided to use the following Ruby API:

```ruby

# Creates a batch message
client.messages.batch.create([message1, message2,...])

# returns a batch 
client.messages.batch.get(id)

# returns a batch result 
client.messages.batch.get_result(result)

# returns the list of batches 
client.messages.batch.list(result, parameters)

# cancels a batch 
client.messages.batch.cancel(id)
```

I implemented the methods mentioned above [in this PR](https://github.com/ignacio-chiazzo/anthropic/pull/1) https://github.com/ignacio-chiazzo/anthropic/pull/1