### PR TITLE
Handle API errors when the token has issues (invalid or low credits)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ client = Anthropic::Client.new(
   access_token: "access_token_goes_here",
   anthropic_version: "2023-01-01", # Optional
   request_timeout: 240 # Optional
+  log_errors = true # Optional
 )
 ```
 
@@ -87,6 +88,7 @@ Anthropic.configure do |config|
   config.access_token = ENV.fetch("ANTHROPIC_API_KEY")
   config.anthropic_version = "2023-01-01" # Optional
   config.request_timeout = 240 # Optional
+  config.log_errors = true # Optional
 end
 ```
 

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -12,23 +12,23 @@ module Anthropic
   class MiddlewareErrors < Faraday::Middleware
     def call(env)
       @app.call(env)
-    rescue Faraday::Error => e
-      raise e unless e.response.is_a?(Hash)
+      rescue Faraday::Error => e
+        raise e unless e.response.is_a?(Hash)
 
-      logger = Logger.new($stdout)
-      logger.formatter = proc do |_severity, _datetime, _progname, msg|
-        "\033[31mAnthropic HTTP Error (spotted in ruby-anthropic #{VERSION}): #{msg}\n\033[0m"
+        logger = Logger.new($stdout)
+        logger.formatter = proc do |_severity, _datetime, _progname, msg|
+          "\033[31mAnthropic HTTP Error (spotted in ruby-anthropic #{VERSION}): #{msg}\n\033[0m"
+        end
+        logger.error(e.response[:body])
+
+        raise e
       end
-      logger.error(e.response[:body])
-
-      raise e
-    end
   end
 
   class Configuration
     attr_writer :access_token
     attr_accessor :anthropic_version, :api_version, :extra_headers,
-                  :request_timeout, :uri_base
+                  :request_timeout, :uri_base, :log_errors
 
     DEFAULT_API_VERSION = "v1".freeze
     DEFAULT_ANTHROPIC_VERSION = "2023-06-01".freeze
@@ -39,6 +39,7 @@ module Anthropic
       @access_token = nil
       @api_version = DEFAULT_API_VERSION
       @anthropic_version = DEFAULT_ANTHROPIC_VERSION
+      @log_errors = false
       @uri_base = DEFAULT_URI_BASE
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @extra_headers = {}

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -12,17 +12,17 @@ module Anthropic
   class MiddlewareErrors < Faraday::Middleware
     def call(env)
       @app.call(env)
-      rescue Faraday::Error => e
-        raise e unless e.response.is_a?(Hash)
+    rescue Faraday::Error => e
+      raise e unless e.response.is_a?(Hash)
 
-        logger = Logger.new($stdout)
-        logger.formatter = proc do |_severity, _datetime, _progname, msg|
-          "\033[31mAnthropic HTTP Error (spotted in ruby-anthropic #{VERSION}): #{msg}\n\033[0m"
-        end
-        logger.error(e.response[:body])
-
-        raise e
+      logger = Logger.new($stdout)
+      logger.formatter = proc do |_severity, _datetime, _progname, msg|
+        "\033[31mAnthropic HTTP Error (spotted in ruby-anthropic #{VERSION}): #{msg}\n\033[0m"
       end
+      logger.error(e.response[:body])
+
+      raise e
+    end
   end
 
   class Configuration

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -7,6 +7,7 @@ module Anthropic
       anthropic_version
       api_version
       uri_base
+      log_errors
       request_timeout
       extra_headers
     ].freeze


### PR DESCRIPTION
Re: [issue #29](https://github.com/alexrudall/anthropic/issues/29)

Expose @log_errors as a parameter and make it configurable.


```ruby
client = Anthropic::Client.new(
  access_token: "access_token_goes_here",
  anthropic_version: "2023-01-01", # Optional
  request_timeout: 240 # Optional
  log_errors = true # Optional
)
```

```ruby
Anthropic.configure do |config|
  config.access_token = ENV.fetch("ANTHROPIC_API_KEY")
  config.anthropic_version = "2023-01-01" # Optional
  config.request_timeout = 240 # Optional
  config.log_errors = true # Optional
end
```

## All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
