### PR TITLE
0.4.2: Rename from 'anthropic' to 'ruby-anthropic'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2025-04-10
+
+### Changed
+
+- Rename gem to `ruby-anthropic`!
+- Remove deprecation warning.
+
 ## [0.4.1] - 2025-04-10
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/alexrudall/anthropic. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/anthropic/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at https://github.com/alexrudall/ruby-anthropic. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/ruby-anthropic/blob/main/CODE_OF_CONDUCT.md).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,13 +74,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  ruby-anthropic!
   byebug (~> 11.1.3)
   dotenv (~> 2.8.1)
   racc (~> 1.7.3)
   rake (~> 13.0)
   rspec (~> 3.12)
   rubocop (~> 1.50.2)
+  ruby-anthropic!
   vcr (~> 6.1.0)
   webmock (~> 3.18.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-anthropic (0.4.2)
+    ruby-anthropic (0.4.1)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
@@ -18,20 +18,15 @@ GEM
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     event_stream_parser (1.0.0)
-    faraday (2.13.0)
-      faraday-net_http (>= 2.0, < 3.5)
-      json
-      logger
-    faraday-multipart (1.1.0)
-      multipart-post (~> 2.0)
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
+    faraday (2.7.10)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (3.0.2)
     hashdiff (1.0.1)
     json (2.6.3)
-    logger (1.7.0)
-    multipart-post (2.4.1)
-    net-http (0.6.0)
-      uri
+    multipart-post (2.3.0)
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -67,8 +62,8 @@ GEM
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     unicode-display_width (2.4.2)
-    uri (1.0.3)
     vcr (6.1.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
@@ -79,13 +74,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ruby-anthropic!
   byebug (~> 11.1.3)
   dotenv (~> 2.8.1)
   racc (~> 1.7.3)
   rake (~> 13.0)
   rspec (~> 3.12)
   rubocop (~> 1.50.2)
-  ruby-anthropic!
   vcr (~> 6.1.0)
   webmock (~> 3.18.1)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    anthropic (0.4.1)
+    ruby-anthropic (0.4.2)
       event_stream_parser (>= 0.3.0, < 2.0.0)
       faraday (>= 1)
       faraday-multipart (>= 1)
@@ -18,15 +18,20 @@ GEM
     diff-lcs (1.5.0)
     dotenv (2.8.1)
     event_stream_parser (1.0.0)
-    faraday (2.7.10)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (3.0.2)
+    faraday (2.13.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-multipart (1.1.0)
+      multipart-post (~> 2.0)
+    faraday-net_http (3.4.0)
+      net-http (>= 0.5.0)
     hashdiff (1.0.1)
     json (2.6.3)
-    multipart-post (2.3.0)
+    logger (1.7.0)
+    multipart-post (2.4.1)
+    net-http (0.6.0)
+      uri
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
@@ -62,8 +67,8 @@ GEM
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     unicode-display_width (2.4.2)
+    uri (1.0.3)
     vcr (6.1.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
@@ -74,13 +79,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  anthropic!
   byebug (~> 11.1.3)
   dotenv (~> 2.8.1)
   racc (~> 1.7.3)
   rake (~> 13.0)
   rspec (~> 3.12)
   rubocop (~> 1.50.2)
+  ruby-anthropic!
   vcr (~> 6.1.0)
   webmock (~> 3.18.1)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Anthropic
 
-[![Gem Version](https://badge.fury.io/rb/anthropic.svg)](https://badge.fury.io/rb/anthropic)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/alexrudall/anthropic/blob/main/LICENSE.txt)
-[![CircleCI Build Status](https://circleci.com/gh/alexrudall/anthropic.svg?style=shield)](https://circleci.com/gh/alexrudall/anthropic)
+[![Gem Version](https://badge.fury.io/rb/ruby-anthropic.svg)](https://badge.fury.io/rb/ruby-anthropic)
+[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/alexrudall/ruby-anthropic/blob/main/LICENSE.txt)
+[![CircleCI Build Status](https://circleci.com/gh/alexrudall/ruby-anthropic.svg?style=shield)](https://circleci.com/gh/alexrudall/ruby-anthropic)
 
 > [!IMPORTANT]
 > This gem has been renamed from `anthropic` to `ruby-anthropic`, to make way for the new [official Anthropic Ruby SDK](https://github.com/anthropics/anthropic-sdk-ruby) 🎉
@@ -402,7 +402,7 @@ Then update the version number in `version.rb`, update `CHANGELOG.md`, run `bund
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at <https://github.com/alexrudall/anthropic>. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/anthropic/blob/main/CODE_OF_CONDUCT.md).
+Bug reports and pull requests are welcome on GitHub at <https://github.com/alexrudall/ruby-anthropic>. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/alexrudall/ruby-anthropic/blob/main/CODE_OF_CONDUCT.md).
 
 ## License
 
@@ -410,4 +410,4 @@ The gem is available as open source under the terms of the [MIT License](https:/
 
 ## Code of Conduct
 
-Everyone interacting in the Ruby Anthropic project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/alexrudall/anthropic/blob/main/CODE_OF_CONDUCT.md).
+Everyone interacting in the Ruby Anthropic project's codebases, issue trackers, chat rooms and mailing lists is expected to follow the [code of conduct](https://github.com/alexrudall/ruby-anthropic/blob/main/CODE_OF_CONDUCT.md).

--- a/anthropic.gemspec
+++ b/anthropic.gemspec
@@ -1,19 +1,19 @@
 require_relative "lib/anthropic/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "anthropic"
+  spec.name          = "ruby-anthropic"
   spec.version       = Anthropic::VERSION
   spec.authors       = ["Alex"]
   spec.email         = ["alexrudall@users.noreply.github.com"]
 
   spec.summary       = "Anthropic API + Ruby! 🤖🌌"
-  spec.homepage      = "https://github.com/alexrudall/anthropic"
+  spec.homepage      = "https://github.com/alexrudall/ruby-anthropic"
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.6.0")
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/alexrudall/anthropic"
-  spec.metadata["changelog_uri"] = "https://github.com/alexrudall/anthropic/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/alexrudall/ruby-anthropic"
+  spec.metadata["changelog_uri"] = "https://github.com/alexrudall/ruby-anthropic/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.

--- a/lib/anthropic.rb
+++ b/lib/anthropic.rb
@@ -53,7 +53,7 @@ module Anthropic
     def access_token
       return @access_token if @access_token
 
-      error_text = "Anthropic access token missing! See https://github.com/alexrudall/anthropic#usage"
+      error_text = "Anthropic access token missing! See https://github.com/alexrudall/ruby-anthropic#usage"
       raise ConfigurationError, error_text
     end
   end

--- a/lib/anthropic/client.rb
+++ b/lib/anthropic/client.rb
@@ -26,8 +26,6 @@ module Anthropic
         )
       end
       @faraday_middleware = faraday_middleware
-      log "[WARNING] Gem `anthropic` was renamed to `ruby-anthropic`.
-        Please update your Gemfile to use `ruby-anthropic` version 0.4.2 or later."
     end
 
     # @deprecated (but still works while Anthropic API responds to it)

--- a/lib/anthropic/version.rb
+++ b/lib/anthropic/version.rb
@@ -1,3 +1,3 @@
 module Anthropic
-  VERSION = "0.4.1".freeze
+  VERSION = "0.4.2".freeze
 end


### PR DESCRIPTION
- **Rename gem from 'anthropic' to 'ruby-anthropic'**
- **Remove deprecation warning**

## All Submissions:

* [ ] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
