### PR TITLE
Fix Anthropic config: remove trailing comma in access_token assignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,11 @@ For a more robust setup, you can configure the gem with your API keys, for examp
 ```ruby
 Anthropic.configure do |config|
   # With dotenv
-  config.access_token = ENV.fetch("ANTHROPIC_API_KEY"),
-  # OR
-  # With Rails credentials
-  config.access_token = Rails.application.credentials.dig(:anthropic, :api_key),
+  config.access_token = ENV.fetch("ANTHROPIC_API_KEY")
+
+  # OR with Rails credentials
+  # config.access_token = Rails.application.credentials.dig(:anthropic, :api_key)
+
   config.log_errors = true # Highly recommended in development, so you can see what errors Anthropic is returning. Not recommended in production because it could leak private data to your logs.
 end
 ```


### PR DESCRIPTION
The previous configuration was assigning  the wrong @access_token when initializing a client

This PR fixes a small syntax issue in the initializer example for Anthropic.configure.
Currently, the example in the README shows:

```config.access_token = ENV.fetch("ANTHROPIC_API_KEY"),```
The trailing comma causes Ruby to interpret the value as a single-element array instead of a string:

# Current behavior
```ENV.fetch("ANTHROPIC_API_KEY"),  # => ["sk-ant-api..."]```
This results in @access_token being set to an array (with nil and true as seen in debug output), which leads to an invalid x-api-key authentication error when calling the API.

# Fix:
Removed the trailing comma so the value is correctly assigned as a string:

config.access_token = ENV.fetch("ANTHROPIC_API_KEY")
This change ensures the access_token is passed correctly to the client and avoids 401 authentication errors.

# Why it matters:
The current example can cause confusion for new users and lead to avoidable API authentication failures. This small fix improves developer onboarding and prevents subtle bugs.